### PR TITLE
Add Delphinus package manager support

### DIFF
--- a/Delphinus.Info.json
+++ b/Delphinus.Info.json
@@ -1,0 +1,9 @@
+{
+  "id": "{3C312CF1-7F7E-4D1B-9827-FB43C59383FC}",
+  "name": "CnPack VCL Components",
+  "platforms": "Win32;Win64",
+  "package_compiler_min": 13,
+  "package_compiler_max": 32,
+  "compiler_min": 13,
+  "compiler_max": 32
+}

--- a/Delphinus.Install.json
+++ b/Delphinus.Install.json
@@ -1,0 +1,117 @@
+{
+  "search_pathes": [{
+    "pathes": "Source;Source\\Common;Source\\DbReport;Source\\Graphics;Source\\Lang\\1033;Source\\MultiLang;Source\\NetComm;Source\\NonVisual;Source\\ObjRep;Source\\Skin",
+    "platforms": "Win32;Win64"
+  }],
+  "browsing_pathes": [{
+    "pathes": ";Source\\Common;Source\\DbReport;Source\\Graphics;Source\\Lang\\1033;Source\\MultiLang;Source\\NetComm;Source\\NonVisual;Source\\ObjRep;Source\\Skin",
+    "platforms": "Win32;Win64"
+  }],
+  "source_folders": [{
+    "folder": "."
+  },
+  {
+    "folder": "Doc",
+    "recursive": true
+  },
+  {
+    "folder": "Examples",
+    "recursive": true
+  },
+  {
+    "folder": "Packages",
+    "recursive": true
+  },
+  {
+    "folder": "Source",
+    "recursive": true
+  }],
+  "projects": [{
+    "project": "Packages\\DelphiXE\\CnPack_DXE.dproj",
+    "compiler": 22
+  },
+  {
+    "project": "Packages\\DelphiXE\\dclCnPack_DXE.dproj",
+    "compiler": 22
+  },
+  {
+    "project": "Packages\\DelphiXE2\\dclCnPack_DXE2.dproj",
+    "compiler": 23
+  },
+  {
+    "project": "Packages\\DelphiXE2\\dclCnPack_D6.dpk",
+    "compiler": 23
+  },
+  {
+    "project": "Packages\\DelphiXE3\\CnPack_DXE3.dproj",
+    "compiler": 24
+  },
+  {
+    "project": "Packages\\DelphiXE3\\dclCnPack_DXE3.dproj",
+    "compiler": 24
+  },
+  {
+    "project": "Packages\\DelphiXE4\\CnPack_DXE4.dproj",
+    "compiler": 25
+  },
+  {
+    "project": "Packages\\DelphiXE4\\dclCnPack_DXE4.dproj",
+    "compiler": 25
+  },
+  {
+    "project": "Packages\\DelphiXE5\\CnPack_DXE5.dproj",
+    "compiler": 26
+  },
+  {
+    "project": "Packages\\DelphiXE5\\dclCnPack_DXE5.dproj",
+    "compiler": 26
+  },
+  {
+    "project": "Packages\\DelphiXE6\\CnPack_DXE6.dproj",
+    "compiler": 27
+  },
+  {
+    "project": "Packages\\DelphiXE6\\dclCnPack_DXE6.dproj",
+    "compiler": 27
+  },
+  {
+    "project": "Packages\\DelphiXE7\\CnPack_DXE7.dproj",
+    "compiler": 28
+  },
+  {
+    "project": "Packages\\DelphiXE7\\dclCnPack_DXE7.dproj",
+    "compiler": 28
+  },
+  {
+    "project": "Packages\\DelphiXE8\\CnPack_DXE8.dproj",
+    "compiler": 29
+  },
+  {
+    "project": "Packages\\DelphiXE8\\dclCnPack_DXE8.dproj",
+    "compiler": 29
+  },
+  {
+    "project": "Packages\\Delphi10S\\CnPack_D10S.dproj",
+    "compiler": 30
+  },
+  {
+    "project": "Packages\\Delphi10S\\dclCnPack_D10S.dproj",
+    "compiler": 30
+  },
+  {
+    "project": "Packages\\Delphi101B\\CnPack_D101B.dproj",
+    "compiler": 31
+  },
+  {
+    "project": "Packages\\Delphi101B\\dclCnPack_D101B.dproj",
+    "compiler": 31
+  },
+  {
+    "project": "Packages\\Delphi102T\\CnPack_D102T.dproj",
+    "compiler": 32
+  },
+  {
+    "project": "Packages\\Delphi102T\\dclCnPack_D102T.dproj",
+    "compiler": 32
+  }]
+}

--- a/Delphinus.Install.json
+++ b/Delphinus.Install.json
@@ -4,7 +4,7 @@
     "platforms": "Win32;Win64"
   }],
   "browsing_pathes": [{
-    "pathes": ";Source\\Common;Source\\DbReport;Source\\Graphics;Source\\Lang\\1033;Source\\MultiLang;Source\\NetComm;Source\\NonVisual;Source\\ObjRep;Source\\Skin",
+    "pathes": "Source;Source\\Common;Source\\DbReport;Source\\Graphics;Source\\Lang\\1033;Source\\MultiLang;Source\\NetComm;Source\\NonVisual;Source\\ObjRep;Source\\Skin",
     "platforms": "Win32;Win64"
   }],
   "source_folders": [{

--- a/Packages/Delphi101B/CnPack_D101B.dpk
+++ b/Packages/Delphi101B/CnPack_D101B.dpk
@@ -33,7 +33,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/Delphi101B/dclCnPack_D101B.dpk
+++ b/Packages/Delphi101B/dclCnPack_D101B.dpk
@@ -34,8 +34,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_D101B;
 

--- a/Packages/Delphi102T/CnPack_D102T.dpk
+++ b/Packages/Delphi102T/CnPack_D102T.dpk
@@ -33,7 +33,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/Delphi102T/dclCnPack_D102T.dpk
+++ b/Packages/Delphi102T/dclCnPack_D102T.dpk
@@ -34,8 +34,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_D102T;
 

--- a/Packages/Delphi10S/CnPack_D10S.dpk
+++ b/Packages/Delphi10S/CnPack_D10S.dpk
@@ -33,7 +33,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/Delphi10S/dclCnPack_D10S.dpk
+++ b/Packages/Delphi10S/dclCnPack_D10S.dpk
@@ -34,8 +34,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_D10S;
 

--- a/Packages/DelphiXE/CnPack_DXE.dpk
+++ b/Packages/DelphiXE/CnPack_DXE.dpk
@@ -31,7 +31,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/DelphiXE/dclCnPack_DXE.dpk
+++ b/Packages/DelphiXE/dclCnPack_DXE.dpk
@@ -32,8 +32,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_DXE;
 

--- a/Packages/DelphiXE2/CnPack_DXE2.dpk
+++ b/Packages/DelphiXE2/CnPack_DXE2.dpk
@@ -34,7 +34,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/DelphiXE2/dclCnPack_DXE2.dpk
+++ b/Packages/DelphiXE2/dclCnPack_DXE2.dpk
@@ -32,8 +32,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_DXE2;
 

--- a/Packages/DelphiXE3/CnPack_DXE3.dpk
+++ b/Packages/DelphiXE3/CnPack_DXE3.dpk
@@ -33,7 +33,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/DelphiXE3/dclCnPack_DXE3.dpk
+++ b/Packages/DelphiXE3/dclCnPack_DXE3.dpk
@@ -34,8 +34,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_DXE3;
 

--- a/Packages/DelphiXE4/CnPack_DXE4.dpk
+++ b/Packages/DelphiXE4/CnPack_DXE4.dpk
@@ -33,7 +33,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/DelphiXE4/dclCnPack_DXE4.dpk
+++ b/Packages/DelphiXE4/dclCnPack_DXE4.dpk
@@ -34,8 +34,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_DXE4;
 

--- a/Packages/DelphiXE5/CnPack_DXE5.dpk
+++ b/Packages/DelphiXE5/CnPack_DXE5.dpk
@@ -33,7 +33,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/DelphiXE5/dclCnPack_DXE5.dpk
+++ b/Packages/DelphiXE5/dclCnPack_DXE5.dpk
@@ -34,8 +34,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_DXE5;
 

--- a/Packages/DelphiXE6/CnPack_DXE6.dpk
+++ b/Packages/DelphiXE6/CnPack_DXE6.dpk
@@ -33,7 +33,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/DelphiXE6/dclCnPack_DXE6.dpk
+++ b/Packages/DelphiXE6/dclCnPack_DXE6.dpk
@@ -34,8 +34,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_DXE6;
 

--- a/Packages/DelphiXE7/CnPack_DXE7.dpk
+++ b/Packages/DelphiXE7/CnPack_DXE7.dpk
@@ -33,7 +33,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/DelphiXE7/dclCnPack_DXE7.dpk
+++ b/Packages/DelphiXE7/dclCnPack_DXE7.dpk
@@ -34,8 +34,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_DXE7;
 

--- a/Packages/DelphiXE8/CnPack_DXE8.dpk
+++ b/Packages/DelphiXE8/CnPack_DXE8.dpk
@@ -33,7 +33,9 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   adortl,
+{$ENDIF}
   dsnap,
   xmlrtl,
   soaprtl,

--- a/Packages/DelphiXE8/dclCnPack_DXE8.dpk
+++ b/Packages/DelphiXE8/dclCnPack_DXE8.dpk
@@ -34,8 +34,10 @@ requires
   vcl,
   vclx,
   vcldb,
+{$IFDEF SUPPORT_ADO}
   dclado,
   adortl,
+{$ENDIF}
   designide,
   CnPack_DXE8;
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# cnvcl
+CnPack VCL Components
+
+You can install [Delphinus package manager](https://github.com/Memnarch/Delphinus/wiki/Installing-Delphinus) and install CnPack VCL Components as a package there. (Delphinus-Support)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@
 CnPack VCL Components
 
 You can install [Delphinus package manager](https://github.com/Memnarch/Delphinus/wiki/Installing-Delphinus) and install CnPack VCL Components as a package there. (Delphinus-Support)
+
+## Important!
+If you don't have Delphi Starter Edition please open Source\Common\CnPack.inc and then
+- comment line {$DEFINE PERSONAL_EDITION}
+- uncomment {$DEFINE ENTERPRISE_EDITION}
+- rebuild both packages

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# cnvcl
-CnPack VCL Components
+# CnPack VCL Components
 
 You can install [Delphinus package manager](https://github.com/Memnarch/Delphinus/wiki/Installing-Delphinus) and install CnPack VCL Components as a package there. (Delphinus-Support)
 
 ## Important!
-If you don't have Delphi Starter Edition please open Source\Common\CnPack.inc and then
-- comment line {$DEFINE PERSONAL_EDITION}
-- uncomment {$DEFINE ENTERPRISE_EDITION}
+**If you don't have Delphi Starter Edition** please open
+_Source\Common\CnPack.inc_ and then:
+- comment line `{$DEFINE PERSONAL_EDITION}`
+- uncomment `{$DEFINE ENTERPRISE_EDITION}`
 - rebuild both packages

--- a/Source/Common/CnPack.inc
+++ b/Source/Common/CnPack.inc
@@ -29,8 +29,8 @@
 // 功能配置选项
 //==============================================================================
 
-//{$DEFINE PERSONAL_EDITION}
-{$DEFINE ENTERPRISE_EDITION}
+{$DEFINE PERSONAL_EDITION}
+//{$DEFINE ENTERPRISE_EDITION}
 
 {$IFNDEF PERSONAL_EDITION}
   {$DEFINE SUPPORT_DB}


### PR DESCRIPTION
:bulb: Advantages:
- easier to find / install
- allow to add CnPack VCL Components as a dependency for other Delphinus packages.

The Readme.md and line with keyword "**Delphinus-Support**" in readme is required to find repository via GitHub API.

I also added `$IFDEF SUPPORT_ADO` sections into dpk files because I was unable to compile them in Delphi Starter.
And switched `$DEFINE PERSONAL_EDITION` as default option